### PR TITLE
Resetting `names` to the initial state

### DIFF
--- a/test_quantity.py
+++ b/test_quantity.py
@@ -247,3 +247,4 @@ def test_number_recognition():
         hprec=None, mprec=None, spacer=None, unity=None, output=None,
         ignore_sf=None, assign_fmt=None, assign_rec=None
     )
+    names.clear()


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_number_recognition` by resetting `names` to the initial state by calling method `clear`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test_text_processing.py::test_text_processing`:

```
    def test_number_recognition():
        for case in test_cases:
>           assert case.name not in names
E           AssertionError: assert 'grange' not in {'ability', 'acrobat', 'airliner', 'allay', 'amnesty', 'animator', ...}
E            +  where 'grange' = <test_quantity.Case object at 0x7f3adaee22b0>.name
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
